### PR TITLE
Provide parentQuestionId and required to PageLayout.tsx

### DIFF
--- a/backend/data/questions.csv
+++ b/backend/data/questions.csv
@@ -1,5 +1,4 @@
 ,Page,ItemID,ParentItemID,ItemText,Subtext,Mandatory in Section,Type,Response Options,Notes,QuestionOrder
-0,Preamble,,,"Elizabeth: highlight that we work with many groups supporting people in many ways, encourage them to fill out the relevant parts.   Roz: think it's good to pair FCs up with groups to help ",,,DisplayText,,,2
 1,Basic Info,,,Organization Name,,Y,Short Response,,,3
 10,Basic Info,,,How many individuals does your organisation support in one month?,,Y,Numeric,,"Adele- this one always confuses people, need some instruction for how to come up with this",12
 2,Basic Info,,,What region do you operate in?,,Y,MultiSelectWithOther,"Existing regions, or 'Other' which will prompt a short response",,4

--- a/backend/models.py
+++ b/backend/models.py
@@ -42,6 +42,7 @@ class Question(db.Model):
     options = db.Column(JSON, nullable=True)
     order = db.Column(db.Integer, nullable=False)
     allows_additional_input = db.Column(db.Boolean, default=False)
+    parent_question_id = db.Column(db.Integer, db.ForeignKey('question.id'), nullable=True)
 
 
 class SiteAssessment(db.Model):

--- a/backend/serialize/serialize.py
+++ b/backend/serialize/serialize.py
@@ -14,6 +14,8 @@ def serialize_question(q: Question) -> dict:
         "options": q.options,
         "order": q.order,
         "allowsAdditionalInput": q.allows_additional_input,
+        "required": q.required,
+        "parentQuestionId": q.parent_question_id,
     }
 
 def serialize_question_response(r: QuestionResponse) -> dict:

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -28,6 +28,7 @@ export interface Question {
   required: boolean;
   options?: string[]; // Added options for Dropdown, MultiSelect, and SizingGrid types
   allowsAdditionalInput: boolean;
+  parentQuestionId?: number; // for conditional questions
 }
 
 export interface Page {


### PR DESCRIPTION
In order to implement logic surrounding conditional display of question and only allowing people to advance if they have completed all required questions, these data fields have to be provided to the frontend. This commit routes the data correctly.

To test it, I used console.log in PageLayout.tsx and confirmed the values are both present and accurate. The parentQuestionId is present for the warehouse questions and required questions had required set to true.